### PR TITLE
Fix: Make m230205_141256_fcm_senderid migration resilient when module is not bootstrapped

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.2.5 (Unreleased)
+-------------------
+- Fix: Make m230205_141256_fcm_senderid migration resilient when module is not bootstrapped
+
 2.2.4 (May 15, 2026)
 --------------------
 - Fix: Session variable name clashes prevents mobile tokens from being deleted on logout

--- a/migrations/m230205_141256_fcm_senderid.php
+++ b/migrations/m230205_141256_fcm_senderid.php
@@ -12,10 +12,14 @@ class m230205_141256_fcm_senderid extends Migration
      */
     public function safeUp()
     {
-        /** @var \humhub\modules\fcmPush\Module $module */
-        $module = Yii::$app->getModule('fcm-push');
+        if (in_array('sender_id', $this->db->getTableSchema('fcmpush_user', true)->columnNames)) {
+            return;
+        }
 
-        $senderId = $module->getConfigureForm()->senderId;
+        $senderId = $this->db->createCommand(
+            'SELECT value FROM setting WHERE module_id = :moduleId AND name = :name',
+            [':moduleId' => 'fcm-push', ':name' => 'senderId']
+        )->queryScalar();
 
         // Allow null
         $this->addColumn('fcmpush_user', 'sender_id', $this->string()->null()->after('user_id'));
@@ -27,7 +31,6 @@ class m230205_141256_fcm_senderid extends Migration
         }
 
         $this->alterColumn('fcmpush_user', 'sender_id', $this->string()->notNull());
-
     }
 
     /**


### PR DESCRIPTION
## Summary

- Replace `Yii::$app->getModule('fcm-push')->getConfigureForm()->senderId` with a direct `setting` table query — the module may not be registered during `migrate/up` (core `#[WithoutModuleAutoload]` skips third-party module bootstrap)
- Add idempotency guard: if `sender_id` column already exists, skip the migration — prevents duplicate column errors when migration history was cleared (e.g. after module disable/re-enable)

## Test plan

- [ ] Run `migrate/up` on an instance where fcm-push was previously installed — migration should complete without errors
- [ ] Run `migrate/up` a second time — idempotency guard should skip cleanly