### PR TITLE
Fix compatibility with HumHub 1.19 SiteIcon removal

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.2.6 (Unreleased)
+------------------
+- Fix: Compatibility with HumHub 1.19, which removed the `SiteIcon` widget in favor of the `AssetImage` registry (core #8011)
+
 2.2.5 (June 22, 2026)
 ---------------------
 - Fix: Make m230205_141256_fcm_senderid migration resilient when module is not bootstrapped

--- a/module.json
+++ b/module.json
@@ -11,7 +11,7 @@
     "humhub": {
         "minVersion": "1.18"
     },
-    "version": "2.2.5",
+    "version": "2.2.6",
     "screenshots": [
         "resources/screenshot1.PNG",
         "resources/screenshot2.PNG"

--- a/services/MessagingService.php
+++ b/services/MessagingService.php
@@ -30,9 +30,26 @@ class MessagingService
             Yii::$app->name,
             $baseNotification->text(),
             Url::to(['/notification/entry', 'id' => $baseNotification->record->id], true),
-            SiteIcon::getUrl(180),
+            $this->getSiteIconUrl(180),
             NotificationHumHub::findUnseen($user)->count(),
         );
+    }
+
+    /**
+     * Returns the site icon URL for the given square size.
+     *
+     * HumHub 1.19 removed the {@see SiteIcon} widget and replaced it with the
+     * AssetImage registry exposed as `Yii::$app->img`. This module still supports
+     * HumHub 1.18 (see `module.json` `humhub.minVersion`), so fall back to the
+     * legacy widget when the registry is not available.
+     */
+    private function getSiteIconUrl(int $size): ?string
+    {
+        if (Yii::$app->has('img')) {
+            return Yii::$app->img->icon->getUrl(['square' => $size]);
+        }
+
+        return SiteIcon::getUrl($size);
     }
 
     public function processMessage(User $user, string $title, string $body, ?string $url, ?string $imageUrl, ?int $notificationCount)


### PR DESCRIPTION
## Problem

On HumHub core 1.19 the queue worker crashes when sending push notifications:

```
Class "humhub\modules\web\pwa\widgets\SiteIcon" not found
  at services/MessagingService.php:33 (SiteIcon::getUrl(180))
```

Core PR humhub/humhub#8011 removed the `SiteIcon` widget (along with `LogoImage`, `MailHeader`, `LoginBackground`) and migrated it to the new `AssetImage` registry exposed as `Yii::$app->img`.

## Fix

Resolve the site icon URL through the `AssetImage` registry when it is available (`Yii::$app->img->icon->getUrl(['square' => 180])`, mirroring core's own migration in `components/View.php`), and fall back to `SiteIcon::getUrl()` when it is not.

This keeps the module working on both:
- HumHub 1.18 (current stable — has `SiteIcon`, no `img` registry)
- HumHub 1.19+ (has `img` registry, no `SiteIcon`)

The change is backward compatible, so `humhub.minVersion` stays at `1.18`.

## Notes

- Verified via `php -l`; the mapping matches core's migration exactly.
- Not exercised against a live 1.19 queue run.