### PR TITLE
- Fix: Open the notification URL when a notification is clicked while…

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -7,7 +7,7 @@ use humhub\modules\fcmPush\assets\FirebaseAsset;
 use humhub\modules\fcmPush\components\NotificationTargetProvider;
 use humhub\modules\fcmPush\helpers\MobileAppHelper;
 use humhub\modules\fcmPush\helpers\WebAppHelper;
-use humhub\modules\fcmPush\services\DriverService;
+use humhub\modules\fcmPush\services\ServiceWorkerService;
 use humhub\modules\fcmPush\widgets\RegisterDeviceTokenButton;
 use humhub\modules\notification\targets\MobileTargetProvider;
 use humhub\modules\notification\widgets\NotificationSettingsForm;
@@ -43,27 +43,8 @@ class Events
             return;
         }
 
-        $bundle = FirebaseAsset::register(Yii::$app->view);
-
-        $pushDriver = (new DriverService($module->getConfigureForm()))->getWebDriver();
-        $baseUrl = Yii::getAlias($bundle->baseUrl);
-
         // Service Worker Addons
-        $controller->additionalJs .= <<<JS
-            // Give the service worker access to Firebase Messaging.
-            importScripts('{$baseUrl}/firebase-app-compat.js');
-            importScripts('{$baseUrl}/firebase-messaging-compat.js');
-
-            firebase.initializeApp({
-                messagingSenderId: "{$pushDriver->getSenderId()}",
-                projectId: "{$module->getConfigureForm()->getJsonParam('project_id')}",
-                appId: "{$module->getConfigureForm()->firebaseAppId}",
-                apiKey: "{$module->getConfigureForm()->firebaseApiKey}",
-            });
-
-            // Initialize Firebase Cloud Messaging and get a reference to the service
-            firebase.messaging();
-JS;
+        $controller->additionalJs .= (new ServiceWorkerService($module))->getJs();
     }
 
     public static function onLayoutAddonInit($event)

--- a/assets/FcmPushAsset.php
+++ b/assets/FcmPushAsset.php
@@ -24,7 +24,9 @@ class FcmPushAsset extends AssetBundle
      * @inheritdoc
      */
     public $js = [
+        'humhub.firebase.store.js',
         'humhub.firebase.js',
+        'humhub.firebase.notification.js',
     ];
 
     /**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 2.2.8 (Unreleased)
 ------------------
-- Fix: Open the notification URL when a notification is clicked while the app is already open — Firebase only focuses the window without navigating, and iOS PWAs never dispatch the click event to the service worker at all
+- Fix #99: Open the notification URL when a notification is clicked while the app is already open — Firebase only focuses the window without navigating, and iOS PWAs never dispatch the click event to the service worker at all
 
 2.2.7 (July 9, 2026)
 --------------------

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.2.8 (Unreleased)
+------------------
+- Fix: Open the notification URL when a notification is clicked while the app is already open — Firebase only focuses the window without navigating, and iOS PWAs never dispatch the click event to the service worker at all
+
 2.2.7 (July 9, 2026)
 --------------------
 - Fix #96: Notification.requestPermission() not bound to user gesture — iOS PWA push never shown

--- a/module.json
+++ b/module.json
@@ -11,7 +11,7 @@
     "humhub": {
         "minVersion": "1.18"
     },
-    "version": "2.2.7",
+    "version": "2.2.8",
     "screenshots": [
         "resources/screenshot1.PNG",
         "resources/screenshot2.PNG"

--- a/resources/js/humhub.firebase.notification.js
+++ b/resources/js/humhub.firebase.notification.js
@@ -1,0 +1,107 @@
+/**
+ * Opens the URL of a tapped push notification on platforms where the click
+ * could not be handled in the service worker.
+ *
+ * Workaround for an iOS bug (iOS 17/18): when the PWA is already running,
+ * tapping a notification only brings the app to the foreground - the service
+ * worker never gets a notificationclick event. The service worker records the
+ * URL of every displayed notification in IndexedDB at push time (see
+ * humhub.firebase.worker.js). When the app becomes visible again, any recorded
+ * notification that is no longer displayed was tapped (or dismissed), so we
+ * navigate to the most recent one. On other platforms the service worker
+ * handles the click itself and removes the entry beforehand.
+ */
+humhub.module('firebase.notification', function (module, require, $) {
+    const PENDING_MAX_AGE_MS = 30 * 60 * 1000;
+    // Minimum age before a poll-resolved entry may navigate: covers the gap between
+    // the pending entry being written and the notification appearing in
+    // getNotifications() - without it a fresh entry would navigate on arrival.
+    const PENDING_MIN_AGE_MS = 5 * 1000;
+    let _pendingCheckRunning = false;
+    // URLs of notifications this page has observed via getNotifications(). A URL
+    // that was seen displayed and then disappeared was just tapped or dismissed.
+    const _seenDisplayedUrls = {};
+
+    const checkPendingNotificationUrls = function (fromPoll) {
+        if (!window.indexedDB || !navigator.serviceWorker || _pendingCheckRunning) {
+            return;
+        }
+        _pendingCheckRunning = true;
+        Promise.all([
+            fcmPushStore.get('pending-urls').then((list) => list || []),
+            navigator.serviceWorker.ready.then((reg) => reg.getNotifications()),
+            fcmPushStore.get('notifications-observable').catch(() => false),
+        ]).then(function ([pending, notifications, observable]) {
+            if (!pending.length) {
+                return;
+            }
+            const displayedUrls = notifications.map(function (n) {
+                const fcmMsg = n.data && n.data.FCM_MSG;
+                return fcmMsg && ((fcmMsg.fcmOptions && fcmMsg.fcmOptions.link) || (fcmMsg.data && fcmMsg.data.url));
+            });
+            displayedUrls.forEach(function (u) {
+                if (u) {
+                    _seenDisplayedUrls[u] = true;
+                }
+            });
+            // Once one of our notifications has ever been observed as displayed, the
+            // device has proven that getNotifications() works: remember it, so that
+            // "no longer displayed" can be trusted to mean tapped/dismissed.
+            if (!observable && displayedUrls.some((u) => u)) {
+                observable = true;
+                fcmPushStore.set('notifications-observable', true).catch(() => null);
+            }
+            const stillDisplayed = pending.filter((p) => displayedUrls.indexOf(p.url) !== -1);
+            let resolved = pending.filter((p) => displayedUrls.indexOf(p.url) === -1);
+            if (fromPoll) {
+                // No user-driven event brought us here (app in foreground, where a
+                // notification tap fires no event at all), so only navigate for
+                // notifications that demonstrably just disappeared: either this page
+                // saw them displayed, or the device is known to report displayed
+                // notifications and the entry is old enough to rule out the
+                // just-arrived race. If getNotifications() does not work on the
+                // device, the poll never navigates - safe by construction.
+                resolved = resolved.filter((p) => _seenDisplayedUrls[p.url] ||
+                    (observable && Date.now() - p.ts > PENDING_MIN_AGE_MS));
+            }
+            if (!resolved.length) {
+                return;
+            }
+            return fcmPushStore.set('pending-urls', stillDisplayed)
+                .then(function () {
+                    const fresh = resolved.filter((p) => Date.now() - p.ts < PENDING_MAX_AGE_MS);
+                    if (fresh.length) {
+                        const url = fresh[fresh.length - 1].url;
+                        if (url !== window.location.href) {
+                            window.location.assign(url);
+                        }
+                    }
+                });
+        }).catch(function (e) {
+            module.log.info('Pending notification URL check failed.', e);
+        }).then(function () {
+            _pendingCheckRunning = false;
+        });
+    };
+
+    const init = function () {
+        checkPendingNotificationUrls();
+        setInterval(function () {
+            if (!document.hidden) {
+                checkPendingNotificationUrls(true);
+            }
+        }, 3000);
+        document.addEventListener('visibilitychange', function () {
+            if (!document.hidden) {
+                checkPendingNotificationUrls();
+            }
+        });
+        window.addEventListener('focus', function () {
+            checkPendingNotificationUrls();
+        });
+    };
+
+    module.export({
+        init,
+    });
+});

--- a/resources/js/humhub.firebase.store.js
+++ b/resources/js/humhub.firebase.store.js
@@ -1,0 +1,42 @@
+/**
+ * Small IndexedDB key-value store shared between the page and the service
+ * worker. Loaded in both contexts: as an asset before humhub.firebase.js (see
+ * FcmPushAsset), and prepended to the service worker addon before
+ * humhub.firebase.worker.js (see ServiceWorkerService).
+ *
+ * IndexedDB rather than the Cache API: iOS evicts/partitions Cache API storage
+ * of home-screen web apps (observed: receiving a push wiped it), while
+ * IndexedDB persists.
+ */
+const fcmPushStore = (function () {
+    function db() {
+        return new Promise(function (resolve, reject) {
+            const req = indexedDB.open('fcm-push-store', 1);
+            req.onupgradeneeded = function () { req.result.createObjectStore('kv'); };
+            req.onsuccess = function () { resolve(req.result); };
+            req.onerror = function () { reject(req.error); };
+        });
+    }
+
+    return {
+        get: function (key) {
+            return db().then(function (db) {
+                return new Promise(function (resolve, reject) {
+                    const rq = db.transaction('kv', 'readonly').objectStore('kv').get(key);
+                    rq.onsuccess = function () { resolve(rq.result); };
+                    rq.onerror = function () { reject(rq.error); };
+                });
+            });
+        },
+        set: function (key, value) {
+            return db().then(function (db) {
+                return new Promise(function (resolve, reject) {
+                    const tx = db.transaction('kv', 'readwrite');
+                    tx.objectStore('kv').put(value, key);
+                    tx.oncomplete = function () { resolve(); };
+                    tx.onerror = function () { reject(tx.error); };
+                });
+            });
+        },
+    };
+})();

--- a/resources/js/humhub.firebase.worker.js
+++ b/resources/js/humhub.firebase.worker.js
@@ -1,0 +1,91 @@
+/**
+ * Service worker addon for FCM push notifications, appended to the PWA service
+ * worker by ServiceWorkerService after humhub.firebase.store.js (fcmPushStore)
+ * and before the Firebase importScripts, so the notificationclick handler below
+ * is called before Firebase's own handler.
+ */
+
+// Activate updated service workers immediately instead of waiting for all
+// app windows to close - iOS PWAs may otherwise keep an old SW for a long time.
+self.addEventListener('install', function () {
+    self.skipWaiting();
+});
+self.addEventListener('activate', function (event) {
+    event.waitUntil(self.clients.claim());
+});
+
+// Pending notification URLs, shared with the page via IndexedDB.
+// Workaround for an iOS bug (iOS 17/18): when the PWA is already running,
+// tapping a notification only brings the app to the foreground - the
+// notificationclick event is never dispatched. So the URL of every
+// notification we display is recorded here at push time, and the page
+// resolves it when the app becomes visible again (see humhub.firebase.js).
+function fcmReadPending() {
+    return fcmPushStore.get('pending-urls').then(function (list) {
+        return list || [];
+    }).catch(function () { return []; });
+}
+function fcmWritePending(list) {
+    return fcmPushStore.set('pending-urls', list).catch(function () {});
+}
+
+self.addEventListener('push', function (event) {
+    let payload = null;
+    try {
+        payload = event.data ? event.data.json() : null;
+    } catch (e) {
+    }
+    const url = payload && ((payload.fcmOptions && payload.fcmOptions.link) ||
+        (payload.fcm_options && payload.fcm_options.link) ||
+        (payload.data && payload.data.url));
+    if (!url || !payload?.notification) {
+        return;
+    }
+    event.waitUntil(
+        self.clients.matchAll({type: 'window', includeUncontrolled: true}).then(function (clientList) {
+            // Mirrors the Firebase SDK check: with a visible client the push is
+            // forwarded to the page and no notification is shown - nothing pending.
+            if (clientList.some(function (c) { return c.visibilityState === 'visible'; })) {
+                return;
+            }
+            return fcmReadPending().then(function (list) {
+                list.push({url: url, ts: Date.now()});
+                return fcmWritePending(list.slice(-10));
+            });
+        })
+    );
+});
+
+// Handle notification clicks ourselves, before Firebase's own handler, which
+// only focuses an already-open window without navigating it (it delegates
+// navigation to a postMessage the suspended iOS PWA page never receives).
+self.addEventListener('notificationclick', function (event) {
+    const fcmMsg = event.notification && event.notification.data && event.notification.data.FCM_MSG;
+    const url = fcmMsg && ((fcmMsg.fcmOptions && fcmMsg.fcmOptions.link) || (fcmMsg.data && fcmMsg.data.url));
+    if (!url) {
+        return; // Not one of our notifications - leave it to Firebase's handler
+    }
+
+    // Take over completely: prevent Firebase's handler from running.
+    event.stopImmediatePropagation();
+    event.notification.close();
+
+    event.waitUntil(
+        // The click is handled here, so drop the URL from the pending list
+        // (which only exists for iOS, where this event does not fire).
+        fcmReadPending().then(function (list) {
+            return fcmWritePending(list.filter(function (p) { return p.url !== url; }));
+        }).then(function () {
+            return self.clients.matchAll({type: 'window', includeUncontrolled: true});
+        }).then(function (clientList) {
+            const client = clientList.find(function (c) { return 'navigate' in c; });
+            if (!client) {
+                return self.clients.openWindow(url);
+            }
+            return Promise.resolve(client.focus())
+                .catch(function () { return client; })
+                .then(function (c) { return (c || client).navigate(url); })
+                .catch(function () { return self.clients.openWindow(url); });
+        })
+    );
+});

--- a/services/ServiceWorkerService.php
+++ b/services/ServiceWorkerService.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace humhub\modules\fcmPush\services;
+
+use humhub\modules\fcmPush\assets\FirebaseAsset;
+use humhub\modules\fcmPush\Module;
+use Yii;
+
+/**
+ * Builds the JavaScript appended to the PWA service worker
+ * (see Events::onServiceWorkerControllerInit()).
+ */
+class ServiceWorkerService
+{
+    public function __construct(private Module $module)
+    {
+    }
+
+    public function getJs(): string
+    {
+        $bundle = FirebaseAsset::register(Yii::$app->view);
+        $baseUrl = Yii::getAlias($bundle->baseUrl);
+
+        $configureForm = $this->module->getConfigureForm();
+        $pushDriver = (new DriverService($configureForm))->getWebDriver();
+
+        // Notification handling (must be registered before the Firebase importScripts)
+        $js = file_get_contents(dirname(__DIR__) . '/resources/js/humhub.firebase.store.js');
+        $js .= file_get_contents(dirname(__DIR__) . '/resources/js/humhub.firebase.worker.js');
+
+        // Give the service worker access to Firebase Messaging.
+        $js .= <<<JS
+            importScripts('{$baseUrl}/firebase-app-compat.js');
+            importScripts('{$baseUrl}/firebase-messaging-compat.js');
+
+            firebase.initializeApp({
+                messagingSenderId: "{$pushDriver->getSenderId()}",
+                projectId: "{$configureForm->getJsonParam('project_id')}",
+                appId: "{$configureForm->firebaseAppId}",
+                apiKey: "{$configureForm->firebaseApiKey}",
+            });
+
+            // Initialize Firebase Cloud Messaging and get a reference to the service
+            firebase.messaging();
+JS;
+
+        return $js;
+    }
+}


### PR DESCRIPTION
… the app is already open — Firebase only focuses the window without navigating, and iOS PWAs never dispatch the click event to the service worker at all

https://github.com/humhub/humhub-internal/issues/1263